### PR TITLE
Test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,11 @@ before_install:
 install: "pip install -r requirements.txt"
 
 script:
-- python nanotensor/tests.py
+- coverage run --source nanotensor nanotensor/tests.py
 
-after_script: # here's a build step block
-- echo "We can put normal shell commands here"
-- echo "more shell commands here"
+# after_script: # here's a build step block
+# - echo "We can put normal shell commands here"
+# - echo "more shell commands here"
+
+after_success:
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ script:
 # - echo "more shell commands here"
 
 after_success:
-  - codecov
+  - codecov -t 3806b863-7185-4be7-9787-a0c1d7963703

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.com/BD2KGenomics/nanopore-RNN.svg?token=q4uTfLUSZiuL53MqFw8k&branch=master)](https://travis-ci.com/BD2KGenomics/nanopore-RNN)
+[![codecov](https://codecov.io/gh/BD2KGenomics/nanopore-RNN/branch/master/graph/badge.svg)](https://codecov.io/gh/BD2KGenomics/nanopore-RNN)
+
 # NanoTensor
 
 We propose a series of scripts, which are still in development, to label and train a multilayer Bidirectional long short-term memory recurrent neural network to base-call ONT-nanopore reads with modified bases.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ python-dateutil==2.6.0
 pytz==2016.10
 setuptools==32.1.0
 tensorflow==1.1.0
+codecov==2.0.9
+coverage==4.4.1


### PR DESCRIPTION
Added [codecov](https://codecov.io/gh/BD2KGenomics/nanopore-RNN) so we can see coverage of our testing by just adding scripts to the `.travis.yml` file. 

Also added the coverage bar and build status to the top of the `README.md` file. 